### PR TITLE
las-383-reconfigure-all-necessary-be-services-to-support-event

### DIFF
--- a/src/handlers/album_handlers.go
+++ b/src/handlers/album_handlers.go
@@ -60,7 +60,7 @@ func GETAlbumByAlbumID(w http.ResponseWriter, r *http.Request, connPool *m.PGPoo
 	batch := &pgx.Batch{}
 	albumID := r.URL.Query().Get("album_id")
 
-	albumQuery := `SELECT a.album_id, album_name, album_owner, u.first_name, u.last_name, a.created_at, locked_at, unlocked_at, revealed_at, album_cover_id, visibility
+	albumQuery := `SELECT a.album_id, album_name, album_owner, u.first_name, u.last_name, a.created_at, revealed_at, album_cover_id, visibility
 					  FROM albums a
 					  JOIN albumuser au
 					  ON au.album_id=a.album_id
@@ -86,7 +86,7 @@ func GETAlbumByAlbumID(w http.ResponseWriter, r *http.Request, connPool *m.PGPoo
 	}()
 
 	err := batchResults.QueryRow().Scan(&album.AlbumID, &album.AlbumName, &album.AlbumOwner, &album.OwnerFirst, &album.OwnerLast,
-		&album.CreatedAt, &album.LockedAt, &album.UnlockedAt, &album.RevealedAt, &album.AlbumCoverID, &album.Visibility)
+		&album.CreatedAt, &album.RevealedAt, &album.AlbumCoverID, &album.Visibility)
 	if err != nil {
 		log.Print(err)
 		return
@@ -160,7 +160,7 @@ func GETRevealedAlbumsByAlbumID(w http.ResponseWriter, r *http.Request, connPool
 		return
 	}
 
-	albumQuery := `SELECT a.album_id, album_name, album_owner, u.first_name, u.last_name, a.created_at, locked_at, unlocked_at, revealed_at, album_cover_id, visibility
+	albumQuery := `SELECT a.album_id, album_name, album_owner, u.first_name, u.last_name, a.created_at, revealed_at, album_cover_id, visibility
 					  FROM albums a
 					  JOIN albumuser au
 					  ON au.album_id=a.album_id
@@ -179,7 +179,7 @@ func GETRevealedAlbumsByAlbumID(w http.ResponseWriter, r *http.Request, connPool
 		var guests []m.Guest
 
 		err = connPool.Pool.QueryRow(ctx, albumQuery, id).Scan(&album.AlbumID, &album.AlbumName, &album.AlbumOwner, &album.OwnerFirst, &album.OwnerLast,
-			&album.CreatedAt, &album.LockedAt, &album.UnlockedAt, &album.RevealedAt, &album.AlbumCoverID, &album.Visibility)
+			&album.CreatedAt, &album.RevealedAt, &album.AlbumCoverID, &album.Visibility)
 		if err != nil {
 			log.Print(err)
 		}
@@ -230,7 +230,7 @@ func GETRevealedAlbumsByAlbumID(w http.ResponseWriter, r *http.Request, connPool
 func GETAlbumsByUserID(w http.ResponseWriter, r *http.Request, connPool *m.PGPool, uid string, ctx context.Context) {
 	var albums []m.Album
 
-	albumQuery := `SELECT a.album_id, album_name, album_owner, u.first_name, u.last_name, a.created_at, locked_at, unlocked_at, revealed_at, album_cover_id, visibility
+	albumQuery := `SELECT a.album_id, album_name, album_owner, u.first_name, u.last_name, a.created_at, revealed_at, album_cover_id, visibility
 				   FROM albums a
 				   JOIN albumuser au
 				   ON au.album_id=a.album_id
@@ -259,7 +259,7 @@ func GETAlbumsByUserID(w http.ResponseWriter, r *http.Request, connPool *m.PGPoo
 
 		// Create Album Object
 		err := response.Scan(&album.AlbumID, &album.AlbumName, &album.AlbumOwner, &album.OwnerFirst, &album.OwnerLast,
-			&album.CreatedAt, &album.LockedAt, &album.UnlockedAt, &album.RevealedAt, &album.AlbumCoverID, &album.Visibility)
+			&album.CreatedAt, &album.RevealedAt, &album.AlbumCoverID, &album.Visibility)
 		if err != nil {
 			log.Print(err)
 		}

--- a/src/handlers/feed_handlers.go
+++ b/src/handlers/feed_handlers.go
@@ -35,7 +35,7 @@ func GETAppFeed(ctx context.Context, w http.ResponseWriter, connPool *m.PGPool, 
 	albums := []m.Album{}
 
 	query :=
-		`SELECT a.album_id, a.album_name, a.album_owner, u.first_name, u.last_name, a.created_at, a.locked_at, a.unlocked_at, a.revealed_at, a.album_cover_id, a.visibility
+		`SELECT a.album_id, a.album_name, a.album_owner, u.first_name, u.last_name, a.created_at, a.revealed_at, a.album_cover_id, a.visibility
 			FROM albums a
 			JOIN albumuser au
 			ON a.album_id = au.album_id
@@ -51,7 +51,7 @@ func GETAppFeed(ctx context.Context, w http.ResponseWriter, connPool *m.PGPool, 
 			ON au.user_id = fl.friend_id
 			WHERE a.visibility = 'public' OR a.visibility = 'friends'
 			UNION DISTINCT
-			SELECT a.album_id, a.album_name, a.album_owner, u.first_name, u.last_name, a.created_at, a.locked_at, a.unlocked_at, a.revealed_at, a.album_cover_id, a.visibility
+			SELECT a.album_id, a.album_name, a.album_owner, u.first_name, u.last_name, a.created_at, a.revealed_at, a.album_cover_id, a.visibility
 			FROM albums a
 			JOIN albumuser au
 			ON a.album_id = au.album_id
@@ -69,7 +69,7 @@ func GETAppFeed(ctx context.Context, w http.ResponseWriter, connPool *m.PGPool, 
 		var album m.Album
 
 		err := response.Scan(&album.AlbumID, &album.AlbumName, &album.AlbumOwner, &album.OwnerFirst, &album.OwnerLast,
-			&album.CreatedAt, &album.LockedAt, &album.UnlockedAt, &album.RevealedAt, &album.AlbumCoverID, &album.Visibility)
+			&album.CreatedAt, &album.RevealedAt, &album.AlbumCoverID, &album.Visibility)
 		if err != nil {
 			WriteErrorToWriter(w, "Scanning SQL response failed")
 			log.Printf("Scanning the response failed with: %v", err)

--- a/src/models/album.go
+++ b/src/models/album.go
@@ -13,8 +13,6 @@ type Album struct {
 	OwnerLast    string    `json:"owner_last"`
 	AlbumCoverID string    `json:"album_cover_id"`
 	CreatedAt    time.Time `json:"created_at"`
-	LockedAt     time.Time `json:"locked_at"`
-	UnlockedAt   time.Time `json:"unlocked_at"`
 	RevealedAt   time.Time `json:"revealed_at"`
 	Visibility   string    `json:"visibility"`
 	InviteList   []Guest   `json:"invite_list"`


### PR DESCRIPTION
Removed all remaining evidence of locked_at and unlocked_at concepts from the codebase to make it safe to deprecate the columns from the database.