### PR TITLE
las-387-change-date-of-image-to-be-captured-datetime-vs-upload

### DIFF
--- a/src/main.go
+++ b/src/main.go
@@ -6,6 +6,7 @@ import (
 	firebase "firebase.google.com/go/v4"
 	"fmt"
 	"github.com/gorilla/mux"
+	"github.com/joho/godotenv"
 	"github.com/redis/go-redis/v9"
 	h "last_weekend_services/src/handlers"
 	i "last_weekend_services/src/inits"
@@ -20,11 +21,11 @@ func main() {
 	ctx := context.Background()
 
 	//Remove when pushing commit - only for local testing
-	//err := godotenv.Load()
-	//if err != nil {
-	//	fmt.Println("cannot get env variables:", err)
-	//	os.Exit(1)
-	//}
+	err := godotenv.Load()
+	if err != nil {
+		fmt.Println("cannot get env variables:", err)
+		os.Exit(1)
+	}
 
 	port, err := strconv.Atoi(os.Getenv("PORT"))
 	if err != nil {

--- a/src/models/image.go
+++ b/src/models/image.go
@@ -16,4 +16,5 @@ type Image struct {
 	UserUpvoted bool      `json:"user_upvoted"`
 	UserLiked   bool      `json:"user_liked"`
 	CreatedAt   time.Time `json:"created_at"`
+	CapturedAt  time.Time `json:"captured_at"`
 }


### PR DESCRIPTION
Made changes to support the change of which time is used for images - in order for this update to work the following changes are required to be made to the database. captured_at datetime added to db with default being current time, update all existing captured_at's (after update) to be the original created_at time.