### PR TITLE
V1.0.10 3

### DIFF
--- a/src/handlers/album_handlers.go
+++ b/src/handlers/album_handlers.go
@@ -476,6 +476,20 @@ func WriteErrorToWriter(w http.ResponseWriter, errorString string) {
 	w.Write(responseBytes)
 }
 
+func WriteResponseWithCode(w http.ResponseWriter, code int, message string) {
+	jsonString, err := json.MarshalIndent(message, "", "\t")
+	if err != nil {
+		log.Print(err)
+		return
+	}
+
+	responseBytes := []byte(jsonString)
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(code)
+	w.Write(responseBytes)
+}
+
 func SendAlbumRequests(ctx context.Context, album *m.Album, invited []m.Guest, rdb *redis.Client, connPool *m.PGPool, messagingClient *messaging.Client) error {
 	query := `INSERT INTO album_requests (album_id, invited_id) 
 										VALUES ($1, $2) RETURNING request_id, updated_at, invite_seen, response_seen, status`

--- a/src/main.go
+++ b/src/main.go
@@ -6,7 +6,6 @@ import (
 	firebase "firebase.google.com/go/v4"
 	"fmt"
 	"github.com/gorilla/mux"
-	"github.com/joho/godotenv"
 	"github.com/redis/go-redis/v9"
 	h "last_weekend_services/src/handlers"
 	i "last_weekend_services/src/inits"
@@ -21,11 +20,11 @@ func main() {
 	ctx := context.Background()
 
 	//Remove when pushing commit - only for local testing
-	err := godotenv.Load()
-	if err != nil {
-		fmt.Println("cannot get env variables:", err)
-		os.Exit(1)
-	}
+	//err := godotenv.Load()
+	//if err != nil {
+	//	fmt.Println("cannot get env variables:", err)
+	//	os.Exit(1)
+	//}
 
 	port, err := strconv.Atoi(os.Getenv("PORT"))
 	if err != nil {

--- a/src/main.go
+++ b/src/main.go
@@ -6,6 +6,7 @@ import (
 	firebase "firebase.google.com/go/v4"
 	"fmt"
 	"github.com/gorilla/mux"
+	"github.com/joho/godotenv"
 	"github.com/redis/go-redis/v9"
 	h "last_weekend_services/src/handlers"
 	i "last_weekend_services/src/inits"
@@ -20,11 +21,11 @@ func main() {
 	ctx := context.Background()
 
 	//Remove when pushing commit - only for local testing
-	//err := godotenv.Load()
-	//if err != nil {
-	//	fmt.Println("cannot get env variables:", err)
-	//	os.Exit(1)
-	//}
+	err := godotenv.Load()
+	if err != nil {
+		fmt.Println("cannot get env variables:", err)
+		os.Exit(1)
+	}
 
 	port, err := strconv.Atoi(os.Getenv("PORT"))
 	if err != nil {

--- a/src/main.go
+++ b/src/main.go
@@ -120,17 +120,18 @@ func main() {
 	r.Handle("/image/like", jwtMiddleware(h.ImageEndpointHandler(connPool, rdb, ctx))).Methods("POST", "DELETE")                         // Protected
 	r.Handle("/image/upvote", jwtMiddleware(h.ImageEndpointHandler(connPool, rdb, ctx))).Methods("POST", "DELETE")                       // Protected
 	r.Handle("/album", jwtMiddleware(h.AlbumEndpointHandler(connPool, rdb, ctx, messagingClient))).Methods("GET")
-	r.Handle("/album/visibility", jwtMiddleware(h.AlbumEndpointHandler(connPool, rdb, ctx, messagingClient))).Methods("PATCH")                        // Protected
-	r.Handle("/album/images", jwtMiddleware(h.AlbumEndpointHandler(connPool, rdb, ctx, messagingClient))).Methods("GET")                              // Protected
-	r.Handle("/album/revealed", jwtMiddleware(h.AlbumEndpointHandler(connPool, rdb, ctx, messagingClient))).Methods("GET")                            // Protected
-	r.Handle("/album/guests", jwtMiddleware(h.AlbumEndpointHandler(connPool, rdb, ctx, messagingClient))).Methods("GET", "POST")                      // Protected
-	r.Handle("/upload", jwtMiddleware(h.ContentEndpointHandler(ctx, connPool, *gcpStorage, storageBucket, stagingBucket))).Methods("GET")             // Protected
-	r.Handle("/user", jwtMiddleware(h.UserEndpointHandler(connPool, ctx))).Methods("GET", "POST", "PATCH")                                            // Protected
-	r.Handle("/user/id", jwtMiddleware(h.UserEndpointHandler(connPool, ctx))).Methods("GET")                                                          // Protected
-	r.Handle("/user/album", jwtMiddleware(h.AlbumEndpointHandler(connPool, rdb, ctx, messagingClient))).Methods("GET", "POST")                        // Protected
-	r.Handle("/user/album/image", jwtMiddleware(h.ImageEndpointHandler(connPool, rdb, ctx))).Methods("GET", "POST")                                   // Protected
-	r.Handle("/user/recap", jwtMiddleware(h.ImageEndpointHandler(connPool, rdb, ctx))).Methods("POST")                                                // Protected
-	r.Handle("/user/image", jwtMiddleware(h.ImageEndpointHandler(connPool, rdb, ctx))).Methods("GET", "POST", "PATCH")                                // Protected
+	r.Handle("/album/visibility", jwtMiddleware(h.AlbumEndpointHandler(connPool, rdb, ctx, messagingClient))).Methods("PATCH")            // Protected
+	r.Handle("/album/images", jwtMiddleware(h.AlbumEndpointHandler(connPool, rdb, ctx, messagingClient))).Methods("GET")                  // Protected
+	r.Handle("/album/revealed", jwtMiddleware(h.AlbumEndpointHandler(connPool, rdb, ctx, messagingClient))).Methods("GET")                // Protected
+	r.Handle("/album/guests", jwtMiddleware(h.AlbumEndpointHandler(connPool, rdb, ctx, messagingClient))).Methods("GET", "POST")          // Protected
+	r.Handle("/upload", jwtMiddleware(h.ContentEndpointHandler(ctx, connPool, *gcpStorage, storageBucket, stagingBucket))).Methods("GET") // Protected
+	r.Handle("/user", jwtMiddleware(h.UserEndpointHandler(connPool, ctx))).Methods("GET", "POST", "PATCH")                                // Protected
+	r.Handle("/user/id", jwtMiddleware(h.UserEndpointHandler(connPool, ctx))).Methods("GET")                                              // Protected
+	r.Handle("/user/album", jwtMiddleware(h.AlbumEndpointHandler(connPool, rdb, ctx, messagingClient))).Methods("GET", "POST")            // Protected
+	r.Handle("/user/album/image", jwtMiddleware(h.ImageEndpointHandler(connPool, rdb, ctx))).Methods("GET", "POST")                       // Protected
+	r.Handle("/user/recap", jwtMiddleware(h.ImageEndpointHandler(connPool, rdb, ctx))).Methods("POST")                                    // Protected
+	r.Handle("/user/image", jwtMiddleware(h.ImageEndpointHandler(connPool, rdb, ctx))).Methods("GET", "POST", "PATCH")
+	r.Handle("/user/image", jwtMiddleware(h.ContentEndpointHandler(ctx, connPool, *gcpStorage, storageBucket, stagingBucket))).Methods("DELETE")      // Protected
 	r.Handle("/user/friend", jwtMiddleware(h.FriendEndpointHandler(ctx, connPool, rdb))).Methods("GET", "DELETE")                                     // Protected
 	r.Handle("/friend-request", jwtMiddleware(h.FriendRequestHandler(ctx, connPool, rdb, messagingClient))).Methods("POST", "PUT", "DELETE", "PATCH") // Protected
 	r.Handle("/album-invite", jwtMiddleware(h.AlbumRequestHandler(ctx, connPool, rdb))).Methods("PUT", "DELETE", "PATCH")                             // Protected

--- a/src/models/image.go
+++ b/src/models/image.go
@@ -16,4 +16,5 @@ type Image struct {
 	UserUpvoted bool      `json:"user_upvoted"`
 	UserLiked   bool      `json:"user_liked"`
 	CreatedAt   time.Time `json:"created_at"`
+	CapturedAt  time.Time `json:"captured_at"`
 }


### PR DESCRIPTION
This release contains the following changes:

- Supporting the updates to the captured_at datetime - both in db and go server code
- Created the delete image endpoint - also configured all of the db foreign keys to cascade on delete so I can just call the delete image function.